### PR TITLE
Use lockbox encryption gem

### DIFF
--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'rails', '4.2.7.1'
+gem 'rails', '~> 6.1.7.2'
 gem 'sqlite3'
-gem 'sass-rails', '~> 4.0.3'
+gem 'sassc-rails'
 gem 'uglifier', '>= 1.3.0'
-gem 'coffee-rails', '~> 4.0.0'
+gem 'coffee-rails'
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer',  platforms: :ruby
 

--- a/demo/app/assets/config/manifest.js
+++ b/demo/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link application.css
+//= link application.js

--- a/demo/app/models/user.rb
+++ b/demo/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
-  devise :two_factor_authenticatable
+  devise :two_factor_authenticatable,
+         otp_encrypted_attribute_options: { key: 'f1eb1826bcd03549ed66c26e8a5fa0a55e32e242bc34dc67266b70c818243297' }
 
   devise :registerable, :recoverable, :rememberable,
          :trackable, :validatable

--- a/demo/app/views/home/index.html.erb
+++ b/demo/app/views/home/index.html.erb
@@ -10,10 +10,7 @@
 
   <% if current_user.otp_required_for_login %>
     <%= button_to "Disable 2FA", users_disable_otp_path, :method => :post %>
-    <%= raw RQRCode::render_qrcode(current_user.otp_provisioning_uri(current_user.email, issuer: "Devise-Two-Factor-Demo"),
-                                   :svg,
-                                   :level => :l,
-                                   :unit => 2) %>
+    <%= raw RQRCode::QRCode.new(current_user.otp_provisioning_uri(current_user.email, issuer: "Devise-Two-Factor-Demo")).as_svg() %>
     <br>
   <% end %>
   <%= link_to "Log out", destroy_user_session_path, :method => :delete %>

--- a/demo/db/migrate/20140515190128_devise_create_users.rb
+++ b/demo/db/migrate/20140515190128_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/demo/db/migrate/20140516191259_add_devise_two_factor_to_users.rb
+++ b/demo/db/migrate/20140516191259_add_devise_two_factor_to_users.rb
@@ -1,8 +1,6 @@
-class AddDeviseTwoFactorToUsers < ActiveRecord::Migration
+class AddDeviseTwoFactorToUsers < ActiveRecord::Migration[4.2]
   def change
-    add_column :users, :encrypted_otp_secret, :string
-    add_column :users, :encrypted_otp_secret_iv, :string
-    add_column :users, :encrypted_otp_secret_salt, :string
+    add_column :users, :otp_secret_ciphertext, :text
     add_column :users, :consumed_timestep, :integer
     add_column :users, :otp_required_for_login, :boolean
   end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -1,39 +1,35 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140516191259) do
+ActiveRecord::Schema.define(version: 2014_05_16_191259) do
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                     default: "", null: false
-    t.string   "encrypted_password",        default: "", null: false
-    t.string   "reset_password_token"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",             default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "encrypted_otp_secret"
-    t.string   "encrypted_otp_secret_iv"
-    t.string   "encrypted_otp_secret_salt"
-    t.integer  "consumed_timestep"
-    t.boolean  "otp_required_for_login"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.text "otp_secret_ciphertext"
+    t.integer "consumed_timestep"
+    t.boolean "otp_required_for_login"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
 end

--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -21,15 +21,16 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'railties',       '~> 7.0'
-  s.add_runtime_dependency 'activesupport',  '~> 7.0'
+  s.add_runtime_dependency 'activesupport',  '~> 6.0'
   s.add_runtime_dependency 'devise',         '~> 4.0'
+  s.add_runtime_dependency 'lockbox',        '~> 1.3'
+  s.add_runtime_dependency 'railties',       '~> 6.0'
   s.add_runtime_dependency 'rotp',           '~> 6.0'
 
   s.add_development_dependency 'activemodel'
   s.add_development_dependency 'appraisal'
-  s.add_development_dependency 'bundler',    '> 1.0'
-  s.add_development_dependency 'rspec',      '> 3'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'bundler', '> 1.0'
   s.add_development_dependency 'faker'
+  s.add_development_dependency 'rspec', '> 3'
+  s.add_development_dependency 'simplecov'
 end

--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -1,4 +1,5 @@
 require 'rotp'
+require 'lockbox'
 
 module Devise
   module Models
@@ -7,24 +8,8 @@ module Devise
       include Devise::Models::DatabaseAuthenticatable
 
       included do
-        encrypts :otp_secret, **splattable_encrypted_attr_options
+        has_encrypted :otp_secret, **splattable_encrypted_attr_options
         attr_accessor :otp_attempt
-      end
-
-      def otp_secret
-        # return the OTP secret stored as a Rails encrypted attribute if it
-        # exists. Otherwise return OTP secret stored by the `attr_encrypted` gem
-        return self[:otp_secret] if self[:otp_secret]
-
-        legacy_otp_secret
-      end
-
-      ##
-      # Decrypt and return the `encrypted_otp_secret` attribute which was used in
-      # prior versions of devise-two-factor
-      # See: # https://github.com/tinfoil/devise-two-factor/blob/main/UPGRADING.md
-      def legacy_otp_secret
-        nil
       end
 
       def self.required_fields(klass)

--- a/lib/devise_two_factor/version.rb
+++ b/lib/devise_two_factor/version.rb
@@ -1,3 +1,3 @@
 module DeviseTwoFactor
-  VERSION = '4.2.0'.freeze
+  VERSION = '5.0.0.lockbox'.freeze
 end

--- a/lib/devise_two_factor/version.rb
+++ b/lib/devise_two_factor/version.rb
@@ -1,3 +1,3 @@
 module DeviseTwoFactor
-  VERSION = '5.0.0'.freeze
+  VERSION = '4.2.0'.freeze
 end

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -4,11 +4,11 @@ require 'active_model'
 class TwoFactorAuthenticatableDouble
   extend ::ActiveModel::Callbacks
   include ::ActiveModel::Validations::Callbacks
-  extend  ::Devise::Models
+  extend ::Devise::Models
 
-  # stub out the ::ActiveRecord::Encryption::EncryptableRecord API
+  # stub out the Lockbox API
   attr_accessor :otp_secret
-  def self.encrypts(*attrs)
+  def self.has_encrypted(*attrs)
     nil
   end
 
@@ -49,5 +49,3 @@ describe ::Devise::Models::TwoFactorAuthenticatable do
     end
   end
 end
-
-

--- a/spec/devise/models/two_factor_backupable_spec.rb
+++ b/spec/devise/models/two_factor_backupable_spec.rb
@@ -4,11 +4,11 @@ require 'active_model'
 class TwoFactorBackupableDouble
   extend ::ActiveModel::Callbacks
   include ::ActiveModel::Validations::Callbacks
-  extend  ::Devise::Models
+  extend ::Devise::Models
 
-  # stub out the ::ActiveRecord::Encryption::EncryptableRecord API
+  # stub out the Lockbox API
   attr_accessor :otp_secret
-  def self.encrypts(*attrs)
+  def self.has_encrypted(*attrs)
     nil
   end
 


### PR DESCRIPTION
Enables the usage of this gem for Rails 6 apps (using Lockbox) without the need to use devise-two-factor v4 and lower.

`devise-two-factor` 4.x.x and lower use the [attr_encrypted](https://github.com/attr-encrypted/attr_encrypted) which makes upgrading to Rails 7 a pain as they cannnot coexist. 

By using Lockbox its ensured that the Rails 7 upgrade can be done without hickups and the migration to Rails 7 encrypted attrs can be done when needed.

---
This MR include changes to the demo app as well, to see the actual changes to the gem see commit: [Use Lockbox gem instead of Rails 7 encrypted attrs](https://github.com/tinfoil/devise-two-factor/pull/249/commits/00bf472084faedac5d8a590a81369deec7e0cf70) 

---

Usage example:

```ruby
  devise :two_factor_authenticatable,
          # Any Lockbox options can be specified here
          otp_encrypted_attribute_options: { key: ENV['ENCRYPTION_KEY'] }
```