### PR TITLE
Prevent specs from failing when drift is too low

### DIFF
--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -14,7 +14,8 @@ class TwoFactorAuthenticatableDouble
 
   define_model_callbacks :update
 
-  devise :two_factor_authenticatable
+  devise :two_factor_authenticatable,
+         otp_allowed_drift: 15
 
   attr_accessor :consumed_timestep
 


### PR DESCRIPTION
Fix specs that were failing when using a `otp_allowed_drift` lower than the default OTP interval of 30 seconds